### PR TITLE
Update the legacy API call for the completions open ai API

### DIFF
--- a/server/services/completions.js
+++ b/server/services/completions.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 module.exports = ({ strapi }) => {
   const createCompletion = async ({ model, prompt, temperature, maxTokens }) => {
     try {
-      const response = await fetch(`https://api.openai.com/v1/completions`, {
+      const response = await fetch(`https://api.openai.com/v1/chat/completions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
The /v1/completions is now legacy, we should use /v1/chat/completions